### PR TITLE
fix: bump dependency to avoid error crashing app

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "ejs-locals": "1.0.2",
         "errorhandler": "1.2.0",
         "express": "4.12.4",
-        "express-fileupload": "0.0.5",
+        "express-fileupload": "1.4.0",
         "express-session": "^1.17.2",
         "file-type": "^8.1.0",
         "hbs": "^4.0.4",
@@ -995,14 +995,14 @@
       "dev": true
     },
     "node_modules/busboy": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.3.1.tgz",
-      "integrity": "sha512-y7tTxhGKXcyBxRKAni+awqx8uqaJKrSFSNFSeRG5CsWNdmy2BIK+6VGWEW7TZnIO/533mtMEA4rOevQV815YJw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
       "dependencies": {
-        "dicer": "0.3.0"
+        "streamsearch": "^1.1.0"
       },
       "engines": {
-        "node": ">=4.5.0"
+        "node": ">=10.16.0"
       }
     },
     "node_modules/bytes": {
@@ -1593,17 +1593,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/connect-busboy": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/connect-busboy/-/connect-busboy-0.0.2.tgz",
-      "integrity": "sha1-rFyclmchcYheV2xmsr/ZXTuxEJc=",
-      "dependencies": {
-        "busboy": "*"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/console-browserify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
@@ -1989,17 +1978,6 @@
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
       "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
       "dev": true
-    },
-    "node_modules/dicer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.0.tgz",
-      "integrity": "sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==",
-      "dependencies": {
-        "streamsearch": "0.1.2"
-      },
-      "engines": {
-        "node": ">=4.5.0"
-      }
     },
     "node_modules/diff": {
       "version": "1.4.0",
@@ -2463,17 +2441,14 @@
       }
     },
     "node_modules/express-fileupload": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/express-fileupload/-/express-fileupload-0.0.5.tgz",
-      "integrity": "sha1-QzpxJSWvqYtMkxYlIui/ecaNguc=",
-      "deprecated": "Please upgrade express-fileupload to version 1.1.8+ due to a security vulnerability with the parseNested option",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/express-fileupload/-/express-fileupload-1.4.0.tgz",
+      "integrity": "sha512-RjzLCHxkv3umDeZKeFeMg8w7qe0V09w3B7oGZprr/oO2H/ISCgNzuqzn7gV3HRWb37GjRk429CCpSLS2KNTqMQ==",
       "dependencies": {
-        "connect-busboy": "0.0.2",
-        "fs-extra": "^0.22.1",
-        "streamifier": "^0.1.1"
+        "busboy": "^1.6.0"
       },
       "engines": {
-        "node": ">=0.8.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express-session": {
@@ -2881,16 +2856,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-exists-cached/-/fs-exists-cached-1.0.0.tgz",
       "integrity": "sha1-zyVVTKBQ3EmuZla0HeQiWJidy84="
-    },
-    "node_modules/fs-extra": {
-      "version": "0.22.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.22.1.tgz",
-      "integrity": "sha1-X9b4BJ3JdsoZ6yNV1lgXPKvM4FY=",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^2.1.0",
-        "rimraf": "^2.2.8"
-      }
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -3959,14 +3924,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-    },
-    "node_modules/jsonfile": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
     },
     "node_modules/jsonify": {
       "version": "0.0.0",
@@ -11156,20 +11113,12 @@
         "safe-buffer": "~5.1.0"
       }
     },
-    "node_modules/streamifier": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/streamifier/-/streamifier-0.1.1.tgz",
-      "integrity": "sha1-l+mNj6TRBdYqJpHR3AfoINuN/E8=",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/streamsearch": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
-      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
       "engines": {
-        "node": ">=0.8.0"
+        "node": ">=10.0.0"
       }
     },
     "node_modules/string_decoder": {
@@ -13444,11 +13393,11 @@
       "dev": true
     },
     "busboy": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.3.1.tgz",
-      "integrity": "sha512-y7tTxhGKXcyBxRKAni+awqx8uqaJKrSFSNFSeRG5CsWNdmy2BIK+6VGWEW7TZnIO/533mtMEA4rOevQV815YJw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
       "requires": {
-        "dicer": "0.3.0"
+        "streamsearch": "^1.1.0"
       }
     },
     "bytes": {
@@ -13930,14 +13879,6 @@
         "xdg-basedir": "^3.0.0"
       }
     },
-    "connect-busboy": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/connect-busboy/-/connect-busboy-0.0.2.tgz",
-      "integrity": "sha1-rFyclmchcYheV2xmsr/ZXTuxEJc=",
-      "requires": {
-        "busboy": "*"
-      }
-    },
     "console-browserify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
@@ -14262,14 +14203,6 @@
           "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
           "dev": true
         }
-      }
-    },
-    "dicer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.0.tgz",
-      "integrity": "sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==",
-      "requires": {
-        "streamsearch": "0.1.2"
       }
     },
     "diff": {
@@ -14732,13 +14665,11 @@
       }
     },
     "express-fileupload": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/express-fileupload/-/express-fileupload-0.0.5.tgz",
-      "integrity": "sha1-QzpxJSWvqYtMkxYlIui/ecaNguc=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/express-fileupload/-/express-fileupload-1.4.0.tgz",
+      "integrity": "sha512-RjzLCHxkv3umDeZKeFeMg8w7qe0V09w3B7oGZprr/oO2H/ISCgNzuqzn7gV3HRWb37GjRk429CCpSLS2KNTqMQ==",
       "requires": {
-        "connect-busboy": "0.0.2",
-        "fs-extra": "^0.22.1",
-        "streamifier": "^0.1.1"
+        "busboy": "^1.6.0"
       }
     },
     "express-session": {
@@ -14988,16 +14919,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-exists-cached/-/fs-exists-cached-1.0.0.tgz",
       "integrity": "sha1-zyVVTKBQ3EmuZla0HeQiWJidy84="
-    },
-    "fs-extra": {
-      "version": "0.22.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.22.1.tgz",
-      "integrity": "sha1-X9b4BJ3JdsoZ6yNV1lgXPKvM4FY=",
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^2.1.0",
-        "rimraf": "^2.2.8"
-      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -15904,14 +15825,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-    },
-    "jsonfile": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-      "requires": {
-        "graceful-fs": "^4.1.6"
-      }
     },
     "jsonify": {
       "version": "0.0.0",
@@ -21533,15 +21446,10 @@
         }
       }
     },
-    "streamifier": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/streamifier/-/streamifier-0.1.1.tgz",
-      "integrity": "sha1-l+mNj6TRBdYqJpHR3AfoINuN/E8="
-    },
     "streamsearch": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
-      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
     },
     "string_decoder": {
       "version": "0.10.31",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "ejs-locals": "1.0.2",
     "errorhandler": "1.2.0",
     "express": "4.12.4",
-    "express-fileupload": "0.0.5",
+    "express-fileupload": "1.4.0",
     "express-session": "^1.17.2",
     "file-type": "^8.1.0",
     "hbs": "^4.0.4",


### PR DESCRIPTION
When adding a todo item previously an error would occur
![Screenshot 2023-05-10 at 21 23 42](https://github.com/snyk-workshops/EH-Patch-Todo-App/assets/53565854/6578c74a-e841-4ca9-968a-5e1b66bed560)

Bumping the dependency resolves this issue